### PR TITLE
add pyproject.toml for uv install/run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ CLAUDE.md
 .claude/
 tmp/
 debug/
+dist/
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@
 
 Any distro or architecture should work just fine, as long as the above is supported.
 
+### Install/run with [uv](https://github.com/astral-sh/uv)
+
+The fastest path. `uv` handles the Python interpreter, the virtualenv, and the dependency for you.
+
+```
+# install as a global command
+uv tool install git+https://github.com/buzh/slop
+slop
+
+# or run one-shot, without installing
+uvx --from git+https://github.com/buzh/slop slop
+```
+
+To upgrade later: `uv tool upgrade slop`. To remove: `uv tool uninstall slop`.
+
 ### Install/run locally
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "slop"
+description = "A top-like TUI monitor for Slurm HPC clusters"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.9"
+dynamic = ["version"]
+dependencies = [
+    "urwid>=4.0.0",
+]
+
+[project.scripts]
+slop = "slop.main:main"
+
+[project.urls]
+Homepage = "https://github.com/buzh/slop"
+Issues = "https://github.com/buzh/slop/issues"
+Changelog = "https://github.com/buzh/slop/blob/main/CHANGELOG.md"
+
+[tool.hatch.version]
+path = "slop/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["slop"]


### PR DESCRIPTION
Let users install with `uv tool install git+...` or run it ephemerally via `uvx --from git+...`.

Publishing it to PyPi would make it even simpler, with `uvx slop` (although that name is already taken, I'm afraid :\)